### PR TITLE
Fix bug where Python v3.10 is read as 3.1

### DIFF
--- a/SupportFunctions/dataLoading.py
+++ b/SupportFunctions/dataLoading.py
@@ -26,8 +26,7 @@ def checkVersion():
     Vs = sys.version_info
     VsMajor = Vs[0]
     VsMinor = Vs[1]
-    Vs = float('{}.{}'.format(VsMajor, VsMinor))
-    if Vs < 3.6:
+    if VsMajor < 3 and VsMinor < 6:
         print('Python version must be 3.6+ to use loadInputs function due to \
 the necessity of ordered dictionary keys. Please upgrade to v. 3.6 or higher.')
         exit()


### PR DESCRIPTION
Currently, the conversion of python versions to floats means that python 3.10 becomes 3.1, and so fails the >3.6 test.
Bug fixed.