### PR TITLE
Allow backwards compatibility with scipy.integrate.cumulative_trapezoid

### DIFF
--- a/SupportFunctions/PDFanalysis.py
+++ b/SupportFunctions/PDFanalysis.py
@@ -9,8 +9,11 @@ Rob Zinke 2019-2021
 ### IMPORT MODULES ---
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.integrate import cumtrapz
 from scipy.interpolate import interp1d
+try:
+    from scipy.integrate import cumulative_trapezoid as sp_cumulative_trapezoid
+except ImportError:
+    from scipy.integrate import cumtrapz as sp_cumulative_trapezoid
 
 
 ### PDF ANALYSIS CLASSES ---
@@ -35,7 +38,7 @@ class IQRpdf:
         # Integrate to CDF
         P = np.trapz(px, x) # check that area = 1.0
         px /= P  # normalize
-        Px = cumtrapz(px, x, initial=0)
+        Px = cumulative_trapezoid(px, x, initial=0)
 
         # Interpolate CDF to back-calculate values
         Icdf = interp1d(Px, x, kind='linear')
@@ -274,3 +277,11 @@ def smoothPDF(x, px, ktype, kwidth):
     px /= P
 
     return px
+
+
+def cumulative_trapezoid(*args, **kwargs):
+    """
+    Function to allow cumulative trapezoid integration without updating
+    scipy, or potentially having to upgrade python to 3.7
+    """
+    return sp_cumulative_trapezoid(*args, **kwargs)

--- a/SupportFunctions/dataLoading.py
+++ b/SupportFunctions/dataLoading.py
@@ -26,7 +26,7 @@ def checkVersion():
     Vs = sys.version_info
     VsMajor = Vs[0]
     VsMinor = Vs[1]
-    if VsMajor < 3 and VsMinor < 6:
+    if VsMajor < 3 or (VsMajor == 3 and VsMinor < 6):
         print('Python version must be 3.6+ to use loadInputs function due to \
 the necessity of ordered dictionary keys. Please upgrade to v. 3.6 or higher.')
         exit()

--- a/SupportFunctions/slipRateObjects.py
+++ b/SupportFunctions/slipRateObjects.py
@@ -8,7 +8,6 @@ Rob Zinke 2019-2021
 ### IMPORT MODULES ---
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.integrate import cumtrapz
 from PDFanalysis import *
 from array2pdf import arrayHist, arrayKDE
 from PDFanalysis import IQRpdf, HPDpdf
@@ -86,7 +85,7 @@ class ageDatum:
         Sum values to cumulative distribution function (CDF).
         '''
         # Sum to CDF
-        self.cdf = cumtrapz(self.probs, self.ages, initial=0)
+        self.cdf = cumulative_trapezoid(self.probs, self.ages, initial=0)
 
     def __uniqueCDF__(self):
         '''
@@ -215,7 +214,7 @@ class dspDatum:
         Sum values to cumulative distribution function (CDF).
         '''
         # Sum to CDF
-        self.cdf = cumtrapz(self.probs, self.dsps, initial=0)
+        self.cdf = cumulative_trapezoid(self.probs, self.dsps, initial=0)
 
     def __uniqueCDF__(self):
         '''

--- a/calyr2age.py
+++ b/calyr2age.py
@@ -11,8 +11,7 @@ import argparse
 import numpy as np
 import matplotlib.pyplot as plt
 from datetime import date
-from scipy.integrate import cumtrapz
-from PDFanalysis import smoothPDF
+from PDFanalysis import smoothPDF, cumulative_trapezoid
 from resultSaving import confirmOutputDir
 
 
@@ -143,7 +142,7 @@ def plotPDF(xDate, pxDate, xAge, pxAge, refDate, ageFactor):
     Plot date and equivalent age PDFs.
     '''
     # Calculate CDF
-    PxAge=cumtrapz(pxAge, xAge, initial=0)
+    PxAge=cumulative_trapezoid(pxAge, xAge, initial=0)
 
     # Set up figure
     fig = plt.figure()

--- a/viewPDF.py
+++ b/viewPDF.py
@@ -9,10 +9,9 @@ Rob Zinke 2019-2021
 ### IMPORT MODULES ---
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.integrate import cumtrapz
 from scipy.interpolate import interp1d
 from resultSaving import confirmOutputDir
-
+from PDFanalysis import cumulative_trapezoid
 
 ### PARSER ---
 # Command line parser
@@ -82,7 +81,7 @@ class pdfStats:
         Find percentiles.
         '''
         # Compute CDF
-        Px = cumtrapz(px, x, initial=0)
+        Px = cumulative_trapezoid(px, x, initial=0)
 
         # Inverse transform
         Icdf=interp1d(Px, x, kind='linear', bounds_error=False, fill_value=np.nan)


### PR DESCRIPTION
cumulative_trapezoid was renamed in scipy 1.6.0, and the old name dropped in 1.14.0, thus throwing an import error for anyone with the latest version of scipy @https://github.com/scipy/scipy/pull/12934

We could have just changed the import line, but as scipy 1.6.0 requires python 3.7+, and RISeR checks for 3.6+, to maintain compatibility for anyone still using 3.6 it seemed neater to add cumulative_trapezoid as a function in PDFanalysis rather than multiple try/except statements
